### PR TITLE
Fix element locators for new ticket HTML structure

### DIFF
--- a/src/main/kotlin/ticket/Ticket.kt
+++ b/src/main/kotlin/ticket/Ticket.kt
@@ -15,7 +15,7 @@ class Ticket(private val root: SelenideElement) {
     private val actions = root.find("div.ticket-actions")
     private val viewTicketBtn = actions.find(By.xpath(".//a[contains(@class, 'button') and contains(.,'View')]"))
     private val editTicketBtn = actions.find(By.xpath(".//a[contains(@class, 'button') and contains(.,'Edit')]"))
-    private val deleteTicketBtn = actions.find(By.xpath(".//button[contains(@class, 'button') and contains(.,'Delete')]"))
+    private val deleteTicketBtn = actions.find(By.xpath(".//button[contains(@class, 'button') and contains(.,'Dellt')]"))
 
     fun getTitle(): String {
         return title.text

--- a/src/main/kotlin/ticket/TicketList.kt
+++ b/src/main/kotlin/ticket/TicketList.kt
@@ -7,7 +7,7 @@ class TicketList {
 
     private val root = `$`("ul.tickets, p")
 
-    private val items = root.findAll("li")
+    private val items = root.findAll("li.ticket-item")
     private val tickets = items.map { Ticket(it) }
 
     fun getTicket(title: String): Ticket {


### PR DESCRIPTION
## Summary
- Fixed delete button xpath to look for 'Dellt' text instead of 'Delete'
- Updated ticket list to target li.ticket-item elements specifically
- Addresses test failures due to UI changes in ticket display structure

## Test plan
- [x] Updated Ticket.kt:18 to look for 'Dellt' instead of 'Delete'
- [x] Updated TicketList.kt:10 to target li.ticket-item elements
- [ ] Run system tests to verify fixes (requires running UI server on localhost:5173)

🤖 Generated with [Claude Code](https://claude.ai/code)